### PR TITLE
Resolve undefined symbol errors when loading CelerUserActionPlugin

### DIFF
--- a/FullSimLight/Plugins/GPUPlugins/CMakeLists.txt
+++ b/FullSimLight/Plugins/GPUPlugins/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   # Make the root module directory visible to CMake.
   list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake )
   # get global GeoModel version
-  include( GeoModel-version ) 
+  include( GeoModel-version )
   # set the project, with the version taken from the GeoModel parent project
   # Later find of Celeritas/AdePT will enable CUDA if it's needed
   project( GPUPlugins VERSION ${GeoModel_VERSION} LANGUAGES CXX )
@@ -44,16 +44,15 @@ find_package(Geant4 REQUIRED)
 # Important note: the library name must match that used in the plugin creator function
 # i.e. if we have "libFooBar.so", then there must be a "createFooBar" `extern "C"` function
 # to return a new-d instance of the plugin.
-add_library(CelerUserActionPlugin MODULE 
+add_library(CelerUserActionPlugin SHARED
   src/Celeritas.hh
   src/Celeritas.cc
   src/CelerUserActionPlugin.cc)
-target_link_libraries(CelerUserActionPlugin PRIVATE FullSimLight::FullSimLight)
 
 include(CeleritasLibrary)
-celeritas_target_link_libraries(CelerUserActionPlugin PRIVATE Celeritas::accel)
+celeritas_target_link_libraries(CelerUserActionPlugin PRIVATE Celeritas::accel FullSimLight::FullSimLight ${Geant4_LIBRARIES})
 
-# Configure the FSL Json file 
+# Configure the FSL Json file
 configure_file(celer-testem3.fsl.json celer-testem3.fsl.json @ONLY)
 
 # TODO: Add installation commands

--- a/FullSimLight/Plugins/GPUPlugins/CMakeLists.txt
+++ b/FullSimLight/Plugins/GPUPlugins/CMakeLists.txt
@@ -49,8 +49,11 @@ add_library(CelerUserActionPlugin SHARED
   src/Celeritas.cc
   src/CelerUserActionPlugin.cc)
 
-include(CeleritasLibrary)
-celeritas_target_link_libraries(CelerUserActionPlugin PRIVATE Celeritas::accel FullSimLight::FullSimLight ${Geant4_LIBRARIES})
+# Link explicitly to Celeritas's accel and accel_final targets if the latter exists. We don't use celeritas_target_link_libraries
+# as this will only link in the _final (containing device code) library in an executable.
+# Target is only present with device builds, so protect with genex.
+target_link_libraries(CelerUserActionPlugin Celeritas::accel $<TARGET_NAME_IF_EXISTS:Celeritas::accel_final> FullSimLight::FullSimLight ${Geant4_LIBRARIES})
+
 
 # Configure the FSL Json file
 configure_file(celer-testem3.fsl.json celer-testem3.fsl.json @ONLY)


### PR DESCRIPTION
Building the Celeritas FullSimLight plugin on Linux with CUDA compiled/linked fine, but failed to load (on `dlopen`) with error:

```
../libcorecel.so: undefined symbol: __cudaRegisterLinkedBinary_7a9bacf0_9_Filler_cu_267d008c_20601
```

Triaged to use of `celeritas_target_link_libraries` not pulling in the `Celeritas::accel_final` target because the consuming target is a shared library, not an executable. Workaround this by reverting to `target_link_libraries` and an explicit list of Celeritas middle and final targets as needed for CPU/GPU use.