### PR TITLE
Add messenger for Celeritas/Accel SetupOptions

### DIFF
--- a/FullSimLight/Plugins/GPUPlugins/CMakeLists.txt
+++ b/FullSimLight/Plugins/GPUPlugins/CMakeLists.txt
@@ -44,7 +44,7 @@ find_package(Geant4 REQUIRED)
 # Important note: the library name must match that used in the plugin creator function
 # i.e. if we have "libFooBar.so", then there must be a "createFooBar" `extern "C"` function
 # to return a new-d instance of the plugin.
-add_library(CelerUserActionPlugin SHARED
+add_library(CelerUserActionPlugin MODULE
   src/Celeritas.hh
   src/Celeritas.cc
   src/CelerUserActionPlugin.cc)

--- a/FullSimLight/Plugins/GPUPlugins/celer-testem3.fsl.json
+++ b/FullSimLight/Plugins/GPUPlugins/celer-testem3.fsl.json
@@ -20,6 +20,7 @@
         "/process/had/verbose 0",
         "/control/cout/prefixString G4Worker_",
         "/run/numberOfThreads 4",
+        "/celer/outputFile celer-testem3.diag.json",
         "/FSLdet/setField 0.0 tesla",
         "/FSLgun/primaryPerEvt 1",
         "/FSLgun/energy 18.000000 GeV",

--- a/FullSimLight/Plugins/GPUPlugins/celer-testem3.fsl.json
+++ b/FullSimLight/Plugins/GPUPlugins/celer-testem3.fsl.json
@@ -19,7 +19,7 @@
         "/process/em/verbose 0",
         "/process/had/verbose 0",
         "/control/cout/prefixString G4Worker_",
-        "/run/numberOfThreads 8",
+        "/run/numberOfThreads 4",
         "/FSLdet/setField 0.0 tesla",
         "/FSLgun/primaryPerEvt 1",
         "/FSLgun/energy 18.000000 GeV",

--- a/FullSimLight/Plugins/GPUPlugins/src/Celeritas.cc
+++ b/FullSimLight/Plugins/GPUPlugins/src/Celeritas.cc
@@ -5,6 +5,7 @@
 #include <accel/AlongStepFactory.hh>
 #include <accel/LocalTransporter.hh>
 #include <accel/SetupOptions.hh>
+#include <accel/SetupOptionsMessenger.hh>
 #include <accel/SharedParams.hh>
 #include <celeritas/field/UniformFieldData.hh>
 #include <celeritas/io/ImportData.hh>
@@ -42,13 +43,13 @@ SetupOptions& CelerSetupOptions()
         // Using the pre-step point, reconstruct the G4 touchable handle.
         so.sd.locate_touchable = true;
 
-        // Save diagnostic information
-        so.output_file = "celer-user-action-plugin.diag.json";
-
         // Pre-step time is used
         so.sd.pre.global_time = true;
         return so;
     }();
+
+    static auto mess = std::make_unique<SetupOptionsMessenger>(&options);
+
     return options;
 }
 


### PR DESCRIPTION
For future testing of possibly several geometries/systems, it will be helpful to have Celeritas's `SetupOptions` configurable by UI commands. This is a straightforward add largely copied from the `celer-g4` app with a static instance of the messenger bound to the main `SetupOptions`. In the current setup, it's available as soon as the FullSimLight plugin is loaded and constructed (or rather, when `CelerSetupOptions` is called the first time).

The minimal TestEm3 smoke test is updated to use the messenger to set the output diagnostic file as a confirmation/example of use.