### PR TITLE
Explicitly initialize run in G4 UI commands

### DIFF
--- a/FullSimLight/Plugins/GPUPlugins/ATLTileCalTB/celer-atltilecaltb.fsl.json
+++ b/FullSimLight/Plugins/GPUPlugins/ATLTileCalTB/celer-atltilecaltb.fsl.json
@@ -22,6 +22,7 @@
         "/process/had/verbose 0",
         "/control/cout/prefixString G4Worker_",
         "/FSLdet/setField 0.0 tesla",
+        "/run/initialize",
         "/gun/particle pi+",
         "/gun/energy 18 GeV"
     ]


### PR DESCRIPTION
Discovered that trying to set the number of particles at the primary vertex for the ATLTileCalTB example did not change the actual number generated. Traced to the command being called before the run had been initialized, not spotted as defaults otherwise worked, and builtin FSL particle gun initializes run automatically.

Call /run/initialize before commands needing initialization.