### PR TITLE
Use Acceleritas flag to create G4Track when available

### DIFF
--- a/FullSimLight/Plugins/GPUPlugins/ATLTileCalTB/ATLTileCalTB/Celeritas.cc
+++ b/FullSimLight/Plugins/GPUPlugins/ATLTileCalTB/ATLTileCalTB/Celeritas.cc
@@ -31,6 +31,12 @@ SetupOptions& CelerSetupOptions()
     // Use Celeritas "hit processor" to call back to Geant4 SDs.
     so.sd.enabled = true;
 
+    // Since Celeritas #839, creation of track controlled by a flag.
+    // Set to true when available as TileCal scoring needs the track.
+#ifdef ACCEL_HAS_SDTRACK
+    so.sd.track = true;
+#endif
+
     // Only call back for nonzero energy depositions: this is currently a
     // global option for all detectors, so if any SDs extract data from tracks
     // with no local energy deposition over the step, it must be set to false.

--- a/FullSimLight/Plugins/GPUPlugins/ATLTileCalTB/CMakeLists.txt
+++ b/FullSimLight/Plugins/GPUPlugins/ATLTileCalTB/CMakeLists.txt
@@ -1,5 +1,16 @@
 # Copyright (C) 2023 CERN for the benefit of the ATLAS collaboration
 
+# Celeritas introduced option to disable setting of track since 0.3.0
+# As this is on develop, use a compile time check of presence
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_LIBRARIES Celeritas::accel)
+check_cxx_source_compiles("
+  #include <accel/SetupOptions.hh>
+  int main() {
+    celeritas::SDSetupOptions x;
+    x.track = true;
+  }" ACCEL_HAS_SDTRACK)
+
 add_library(ATLTileCalTB SHARED
   ATLTileCalTB/ATLTileCalTBConstants.hh
   ATLTileCalTB/ATLTileCalTBEventAction.cc
@@ -25,6 +36,7 @@ add_library(ATLTileCalTB SHARED
 # as this will only link in the _final (containing device code) library in an executable.
 # Target is only present with device builds, so protect with genex.
 target_link_libraries(ATLTileCalTB PUBLIC Celeritas::accel $<TARGET_NAME_IF_EXISTS:Celeritas::accel_final> ${Geant4_LIBRARIES})
+target_compile_definitions(ATLTileCalTB PRIVATE $<$<BOOL:${ACCEL_HAS_SDTRACK}>:ACCEL_HAS_SDTRACK>)
 target_include_directories(ATLTileCalTB PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)
 
 # Plugins


### PR DESCRIPTION
celeritas-project/celeritas#839 introduced a flag in Acceleritas SDSetupOptions to control reconstitution of G4Tracks in the G4Steps passed back to host-side SDs. It is off by default, leading to segfaults in thr ATLTileCal SDs, which use the track info.

Introduce CMake-time compile check for presence of SDSetupOptions track flag. When available, always set to true so that track info is available in the G4Step.