### PR TITLE
Add compatibility with celeritas v0.3.0

### DIFF
--- a/FullSimLight/Plugins/GPUPlugins/ATLTileCalTB/ATLTileCalTB/Celeritas.cc
+++ b/FullSimLight/Plugins/GPUPlugins/ATLTileCalTB/ATLTileCalTB/Celeritas.cc
@@ -1,4 +1,5 @@
 #include "Celeritas.hh"
+#include "celeritas_version.h"
 
 #include <G4Threading.hh>
 #include <G4Version.hh>
@@ -23,7 +24,11 @@ SetupOptions& CelerSetupOptions()
     // Set along-step factory
     so.make_along_step = celeritas::UniformAlongStepFactory();
 
-    so.action_times = false;
+#if CELERITAS_VERSION >= 0x000500
+        so.action_times = false;
+#else
+        so.sync = false;
+#endif
 
     so.max_num_tracks = 65536;
     so.max_num_events = 10000;
@@ -40,7 +45,7 @@ SetupOptions& CelerSetupOptions()
 
     // Since Celeritas #839, creation of track controlled by a flag.
     // Set to true when available as TileCal scoring needs the track.
-#ifdef ACCEL_HAS_SDTRACK
+#if CELERITAS_VERSION >= 0x000301
     so.sd.track = true;
 #endif
 

--- a/FullSimLight/Plugins/GPUPlugins/ATLTileCalTB/CMakeLists.txt
+++ b/FullSimLight/Plugins/GPUPlugins/ATLTileCalTB/CMakeLists.txt
@@ -1,16 +1,5 @@
 # Copyright (C) 2023 CERN for the benefit of the ATLAS collaboration
 
-# Celeritas introduced option to disable setting of track since 0.3.0
-# As this is on develop, use a compile time check of presence
-include(CheckCXXSourceCompiles)
-set(CMAKE_REQUIRED_LIBRARIES Celeritas::accel)
-check_cxx_source_compiles("
-  #include <accel/SetupOptions.hh>
-  int main() {
-    celeritas::SDSetupOptions x;
-    x.track = true;
-  }" ACCEL_HAS_SDTRACK)
-
 add_library(ATLTileCalTB SHARED
   ATLTileCalTB/ATLTileCalTBConstants.hh
   ATLTileCalTB/ATLTileCalTBEventAction.cc

--- a/FullSimLight/Plugins/GPUPlugins/MinCeleritas/MinCeleritas/Celeritas.cc
+++ b/FullSimLight/Plugins/GPUPlugins/MinCeleritas/MinCeleritas/Celeritas.cc
@@ -1,4 +1,5 @@
 #include "Celeritas.hh"
+#include "celeritas_version.h"
 
 #include <memory>
 #include <G4Threading.hh>
@@ -25,8 +26,11 @@ SetupOptions& CelerSetupOptions()
         // Set along-step factory
         so.make_along_step = celeritas::UniformAlongStepFactory();
 
+#if CELERITAS_VERSION >= 0x000500
         so.action_times = false;
-
+#else
+        so.sync = false;
+#endif
         so.max_num_tracks = 65536;
         so.max_num_events = 10000;
         so.initializer_capacity = so.max_num_tracks * 128;


### PR DESCRIPTION
Add compatibility with Celeritas v0.3.0

Remove the `check_cxx_source_compile` because it will fail with the same error mentioned [here](https://github.com/celeritas-project/GeoModel/blob/celeritas/FullSimLight/CMakeLists.txt#L63-L67) so it's easier to check for the version